### PR TITLE
Fix unable to use sticker picker when connect to self deployed dimension

### DIFF
--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetPostAPIHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetPostAPIHandler.kt
@@ -38,6 +38,7 @@ import org.matrix.android.sdk.api.session.room.model.PowerLevelsContent
 import org.matrix.android.sdk.api.session.room.powerlevels.PowerLevelsHelper
 import org.matrix.android.sdk.api.session.widgets.WidgetPostAPIMediator
 import org.matrix.android.sdk.api.util.JsonDict
+import org.matrix.android.sdk.api.session.widgets.model.Widget
 import timber.log.Timber
 import java.util.ArrayList
 import java.util.HashMap
@@ -211,12 +212,22 @@ class WidgetPostAPIHandler @AssistedInject constructor(@Assisted private val roo
      * @param eventData the modular data
      */
     private fun getWidgets(widgetPostAPIMediator: WidgetPostAPIMediator, eventData: JsonDict) {
-        if (checkRoomId(widgetPostAPIMediator, eventData)) {
-            return
+//        if (checkRoomId(widgetPostAPIMediator, eventData)) {
+//            return
+//        }
+        val roomIdInEvent = eventData["room_id"] as String?
+        // Check if param is present
+        var allWidgets = emptyList<Widget>()
+        if (null == roomIdInEvent) {
+            allWidgets += session.widgetService().getUserWidgets()
+        } else {
+            if (checkRoomId(widgetPostAPIMediator, eventData)) {
+                return
+            }
+            allWidgets = session.widgetService().getRoomWidgets(roomId) + session.widgetService().getUserWidgets()
         }
         Timber.d("Received request to get widget in room $roomId")
         val responseData = ArrayList<JsonDict>()
-        val allWidgets = session.widgetService().getRoomWidgets(roomId) + session.widgetService().getUserWidgets()
         for (widget in allWidgets) {
             val map = widget.event.toContent()
             responseData.add(map)

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetViewModel.kt
@@ -219,7 +219,7 @@ class WidgetViewModel @AssistedInject constructor(@Assisted val initialState: Wi
                         baseUrl = initialState.baseUrl,
                         params = initialState.urlParams,
                         forceFetchScalarToken = forceFetchToken,
-                        bypassWhitelist = initialState.widgetKind == WidgetKind.INTEGRATION_MANAGER
+                        bypassWhitelist = initialState.widgetKind == WidgetKind.INTEGRATION_MANAGER || initialState.widgetKind == WidgetKind.STICKER_PICKER
                 )
                 setState { copy(formattedURL = Success(formattedUrl)) }
                 Timber.v("Post load formatted url event: $formattedUrl")


### PR DESCRIPTION
Fix get Widgets when using sticker picker 
Noted: there still problem to  enable sticker picker for the  first time, if we want to use sticker picker, we should enable it on element-web then we can use 
 sticker picker in android with self deployed dimension